### PR TITLE
Update 3_analogbase.ipynb

### DIFF
--- a/workspace_setup/tutorial_files/3_analogbase.ipynb
+++ b/workspace_setup/tutorial_files/3_analogbase.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "## Transistor Source/Drain Naming Convention\n",
     "<img src=\"bootcamp_pics/3_analogbase/analogbase_3.PNG\" alt=\"Drawing\" style=\"width: 600px;\"/>\n",
-    "Before we talk about how `AnalogBase` draws transistor connections, we need to establish a naming convention for source/drain junctions of a transistor, since source and drain are often interchangeable.  In XBase, the left-most source/drain junction of a transistor is always called \"source\", and after that source and drain alternates between each other, as shown in the above figure.  This implies that for even number of fingers, the right-most junction is always \"source\", and for odd number of fingers, the left-most junction is always \"drain\"."
+    "Before we talk about how `AnalogBase` draws transistor connections, we need to establish a naming convention for source/drain junctions of a transistor, since source and drain are often interchangeable.  In XBase, the left-most source/drain junction of a transistor is always called \"source\", and after that source and drain alternates between each other, as shown in the above figure.  This implies that for even number of fingers, the right-most junction is always \"source\", and for odd number of fingers, the right-most junction is always \"drain\"."
    ]
   },
   {


### PR DESCRIPTION
For odd fingers the right most is always Drain. Even the right most is always Source. This is a simple typo but can be confusing. The left-most is always Source.

I am new to this so let me know if this is what I should be doing.